### PR TITLE
Add macOS support to CI workflow and improve installation conditions for MetaCall

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         env: [cli, faas]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Checkout code
@@ -29,10 +29,12 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install MetaCall (CLI only - Ubuntu)
-        if: matrix.env == 'cli' && matrix.os == 'ubuntu-latest'
+      - name: Install MetaCall (CLI only - Unix)
+        if: matrix.env == 'cli' && matrix.os != 'windows-latest'
         run: |
-          sudo apt update
+          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
+            sudo apt update
+          fi
           curl -sL https://raw.githubusercontent.com/metacall/install/master/install.sh | sh
           metacall
 


### PR DESCRIPTION
## Description
Adds macOS testing to the GitHub Actions CI pipeline.
- Fixed #16 

## Changes
- Added `macos-latest` to the test matrix
- Consolidated Unix-based (Ubuntu/macOS) MetaCall CLI installation into a single step
- Made `apt update` conditional to only run on Ubuntu

## Testing Coverage
The CI now tests across 6 platform/environment combinations:
- Ubuntu 
- Windows 
- macOS  ✨ (new)

