### PR TITLE
Improve test failure output for better debugging

### DIFF
--- a/testing/test_runner.py
+++ b/testing/test_runner.py
@@ -18,8 +18,17 @@ class TestCaseGenerator:
             passed = self.check_match(out_str, test_case_expected_stdout)
             self.assertTrue(
                 passed,
-                f"{interface.get_name()}_{test_case_name} - \
-                Expected: {test_case_expected_stdout}, Actual: {out_str}",
+                f"""
+            Test Failed
+            
+            Interface : {interface.get_name()}
+            Test Case : {test_case_name}
+
+            Input: {function_call}
+
+            Expected  : {test_case_expected_stdout}
+            Actual: {out_str}
+            """,
             )
 
         return test_method


### PR DESCRIPTION
SOLVES ISSUE #25 
While going through the testing-center repository, I noticed that when a test fails, the output is a bit hard to read and doesn’t give enough context at a glance.
This change just improves the failure message so it’s easier to understand what went wrong.
Earlier, the failure output was mostly a single line showing expected and actual values together, which made it harder to quickly spot the issue.
With this change, the output is a bit more structured and includes:
- interface name
- test case name
- input used
- expected vs actual output
No changes to the test logic itself, just improving how failures are displayed.