### PR TITLE
ci: add Windows PowerShell support for test runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run Test Suits
+      - name: Run Test Suites (Non-Windows)
+        if: matrix.os != 'windows-latest'
         shell: bash
         run: |
           if [ "${{ matrix.env }}" == "faas" ]; then
@@ -52,3 +53,11 @@ jobs:
             sleep 5  # Wait for the server to start
           fi
           find test-suites -type f -name "*.yaml" -exec python ./testing.py -f {} -V -e ${{ matrix.env }} \;
+
+      - name: Run Test Suite (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: powershell
+        env:
+          MATRIX_ENV: ${{ matrix.env }}
+        run: |
+          python testing.py -f test-suites/test-time-app-web.yaml -V -e $env:MATRIX_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run Test Suites (Non-Windows)
+      - name: Run Test Suits
         if: matrix.os != 'windows-latest'
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,14 +50,19 @@ jobs:
         run: |
           if [ "${{ matrix.env }}" == "faas" ]; then
             metacall faas &
-            sleep 5  # Wait for the server to start
+            sleep 10  # Wait for the server to start
           fi
           find test-suites -type f -name "*.yaml" -exec python ./testing.py -f {} -V -e ${{ matrix.env }} \;
 
       - name: Run Test Suite (Windows)
         if: matrix.os == 'windows-latest'
         shell: powershell
-        env:
-          MATRIX_ENV: ${{ matrix.env }}
         run: |
-          python testing.py -f test-suites/test-time-app-web.yaml -V -e $env:MATRIX_ENV
+          if ("${{ matrix.env }}" -eq "faas") {
+            Start-Process -FilePath "metacall" -ArgumentList "faas"
+            Start-Sleep -Seconds 10  # Wait for the server to start
+          }
+
+          Get-ChildItem -Path "test-suites" -Recurse -Filter "*.yaml" | ForEach-Object {
+            python ./testing.py -f $_.FullName -V -e "${{ matrix.env }}"
+          }


### PR DESCRIPTION
## What
Added a dedicated Windows step in the CI pipeline using PowerShell.

## Why
The existing test step was using bash on Windows which was hiding platform-specific bugs.

## Changes
- Added if condition to existing step to skip on Windows
- Added new Run Test Suite (Windows) step with PowerShell for windows-latest