### PR TITLE
feat: add test suite for auth-middleware example

### DIFF
--- a/test-suites/test-auth-middleware.yaml
+++ b/test-suites/test-auth-middleware.yaml
@@ -1,0 +1,14 @@
+project: auth-middleware
+repo-url: https://github.com/metacall/examples
+code-files:
+  - path: examples/auth-middleware/middleware.js
+    test-cases:
+      - name: Check signin returns a JWT token
+        function-call: 'signin("viferga", "123")'
+        expected-pattern: 'eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+'
+      - name: Check reverse rejects an invalid token
+        function-call: 'reverse("invalid-token", {"str": "hello"})'
+        expected-pattern: 'jwt malformed'
+      - name: Check sum rejects an invalid token
+        function-call: 'sum("invalid-token", {"a": 1, "b": 2})'
+        expected-pattern: 'jwt malformed'


### PR DESCRIPTION
## What
Added a test suite for the auth-middleware example from metacall/examples.

## Changes
- Added test-suites/test-auth-middleware.yaml

## Test Cases
- Check signin returns a JWT token
- Check reverse rejects an invalid token
- Check sum rejects an invalid token