### PR TITLE
feat: add test suite for auth-function-mesh example

### DIFF
--- a/test-suites/test-auth-function-mesh.yaml
+++ b/test-suites/test-auth-function-mesh.yaml
@@ -1,0 +1,11 @@
+project: auth-function-mesh
+repo-url: https://github.com/metacall/examples
+code-files:
+  - path: examples/auth-function-mesh/auth.py
+    test-cases:
+      - name: Check encrypt returns a JWT token
+        function-call: 'encrypt("asd")'
+        expected-pattern: 'eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+'
+      - name: Check decrypt returns original text
+        function-call: 'decrypt(encrypt("asd"))'
+        expected-pattern: 'asd'


### PR DESCRIPTION
What
Added a test suite for the auth-function-mesh example from metacall/examples.

Changes
- Added test-suites/test-auth-function-mesh.yaml

Test Cases
- Check encrypt returns a JWT token
- Check decrypt returns original text