### PR TITLE
feat: add test suite for string-manipulation example

### DIFF
--- a/test-suites/test-string-manipulation.yaml
+++ b/test-suites/test-string-manipulation.yaml
@@ -1,0 +1,11 @@
+project: string-manipulation
+repo-url: https://github.com/metacall/examples
+code-files:
+  - path: examples/string-manipulation/str.rb
+    test-cases:
+      - name: Check longest repetition is found correctly
+        function-call: longest_repetition("aaaabbb")
+        expected-pattern: '\["a", 4\]'
+      - name: Check empty string returns empty result
+        function-call: longest_repetition("")
+        expected-pattern: '\["", 0\]'


### PR DESCRIPTION
What
Added a test suite for the string-manipulation example from metacall/examples.

Changes
- Added test-suites/test-string-manipulation.yaml

Test Cases
- Check longest repetition is found correctly
- Check empty string returns empty result